### PR TITLE
Fixes for print-value-to-string

### DIFF
--- a/cambl.lisp
+++ b/cambl.lisp
@@ -1702,16 +1702,17 @@ associated with the given commodity pool.
     (multiple-value-bind (quotient remainder)
 	(truncate quantity)
 
-      (format output-stream "~:[~,,vD~;~,,v:D~]"
+      (format output-stream "~@[~a~]~:[~,,vD~;~,,v:D~]"
+              (when (and (zerop quotient) (minusp remainder)) #\-)
 	      (and commodity (commodity-thousand-marks-p commodity))
 	      #\, quotient)
 
       (unless (or (and precision (zerop precision))
 		  (zerop quantity))
-	(format output-stream "~v,0,,'0$"
-		(or precision *default-display-precision*)
-		(abs remainder))))
-      
+        (let* ((p (or precision *default-display-precision*))
+               (r (truncate (* (abs remainder) (expt 10 p)))))
+          (format output-stream ".~v,'0D" p r))))
+
     (when (and commodity-symbol
 	       (not (commodity-symbol-prefixed-p commodity-symbol)))
       (maybe-gap)


### PR DESCRIPTION
-0.5 was printed as 0.5 because the quotient is -0, which is 0,
therefore the sign was ignored.

1.999999999 was printed as 11.00000000 because by default the remainder
99999999/100000000 is converted to a single-float by the ~$ directive
of format, and therefore rounded to 1. ~~Coercing it to a double-float
should allow remainders with up to 16 digits to be printed correctly.~~